### PR TITLE
Feat: LPI2 and PSK2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const compat = require('ilp-compat-plugin')
+const ILDCP = require('ilp-protocol-ildcp')
 const debug = require('debug')('koa-ilp')
 const crypto = require('crypto')
 const ILP = require('ilp')
@@ -57,8 +59,10 @@ module.exports = class KoaIlp {
         ? price(ctx)
         : price)
 
+      const compatPlugin = compat(plugin)
+      const { clientAddress } = await ILDCP.fetch(compatPlugin.sendData.bind(compatPlugin))
       const psk = ILP.PSK.generateParams({
-        destinationAccount: this.plugin.getAccount(),
+        destinationAccount: clientAddress,
         receiverSecret: this.secret
       })
 
@@ -98,9 +102,10 @@ module.exports = class KoaIlp {
         ctx.throw(402, 'No valid payment token provided')
       }
 
-      const ilpAddress = this.plugin.getAccount()
+      const compatPlugin = compat(plugin)
+      const { clientAddress } = await ILDCP.fetch(compatPlugin.sendData.bind(compatPlugin))
       const psk = ILP.PSK.generateParams({
-        destinationAccount: ilpAddress,
+        destinationAccount: clientAddress,
         receiverSecret: this.secret
       })
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "bignumber.js": "^4.0.2",
-    "ilp": "^11.2.0",
+    "ilp": "interledgerjs/ilp#refactor/st-lpi2",
     "ilp-plugin-bells": "^15.0.0",
     "koa-bodyparser": "^4.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
   },
   "dependencies": {
     "bignumber.js": "^4.0.2",
-    "ilp": "interledgerjs/ilp#refactor/st-lpi2",
-    "ilp-plugin-bells": "^15.0.0",
+    "ilp-protocol-psk2": "^0.2.0",
     "koa-bodyparser": "^4.2.0"
   }
 }


### PR DESCRIPTION
Depends on https://github.com/emschwartz/ilp-protocol-psk2/pull/8 .

- changes the payment method to `interledger-psk2`
- uses PSK2 to accept one chunk at a time and then update the balance. The PSK2 paymentId is used to associate with `Pay-Token`.