### PR TITLE
fix: new payment method identifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const PSK2 = require('ilp-protocol-psk2')
 const BigNumber = require('bignumber.js')
 const bodyParser = require('koa-bodyparser')
 
-const PAYMENT_METHOD_IDENTIFIER = 'interledger-psk'
+const PAYMENT_METHOD_IDENTIFIER = 'interledger-psk2'
 
 const base64url = buffer => buffer.toString('base64')
   .replace(/=/g, '')

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = class KoaIlp {
     const psk = this.psk2.generateAddressAndSecret()
 
     // price comes last because it's an optional argument
-    return 'interledger-psk2 ' +
+    return PAYMENT_METHOD_IDENTIFIER + ' ' +
       psk.destinationAccount + ' ' +
       psk.sharedSecret.toString('base64') +
       (price ? (' ' + price) : '')


### PR DESCRIPTION
The 'interledger-psk' payment method identifier relies on PSK-1; now that this module uses PSK-2, its payment method identifier should be updated, right? Or will it still accept PSK-1 payments?